### PR TITLE
feat: add criterias translation mode

### DIFF
--- a/common/src/main/java/codes/atomys/advr/ReloadedCriterionProgress.java
+++ b/common/src/main/java/codes/atomys/advr/ReloadedCriterionProgress.java
@@ -1,8 +1,14 @@
 package codes.atomys.advr;
 
+import codes.atomys.advr.config.Configuration;
+import codes.atomys.advr.utils.Utils;
+import com.google.common.collect.Lists;
+import java.util.List;
 import net.minecraft.advancements.Advancement;
+import net.minecraft.advancements.AdvancementNode;
 import net.minecraft.advancements.AdvancementProgress;
 import net.minecraft.network.chat.Component;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.util.CommonColors;
 
 /**
@@ -12,26 +18,36 @@ import net.minecraft.util.CommonColors;
  * and to get the title and color of the criterion progress.
  */
 public class ReloadedCriterionProgress {
-  private final Advancement advancement;
+  private final AdvancementNode advancementNode;
   private final AdvancementProgress progress;
-  private final String criterionName;
+  private final ResourceLocation criterion;
 
   private boolean obtained;
 
   /**
    * Represents the progress of a specific criterion within an advancement.
    *
-   * @param advancement   The advancement to which the criterion belongs.
-   * @param progress      The overall progress of the advancement.
-   * @param criterionName The name of the criterion being tracked.
+   * @param advancementNode The advancement node to which the criterion
+   *                        belongs.
+   * @param progress        The overall progress of the advancement.
+   * @param criterionName   The name of the criterion being tracked.
    */
-  public ReloadedCriterionProgress(final Advancement advancement, final AdvancementProgress progress,
+  public ReloadedCriterionProgress(final AdvancementNode advancementNode, final AdvancementProgress progress,
       final String criterionName) {
-    this.advancement = advancement;
+    this.advancementNode = advancementNode;
     this.progress = progress;
-    this.criterionName = criterionName;
+    this.criterion = ResourceLocation.parse(criterionName);
 
     this.obtained = progress.getCriterion(criterionName).isDone();
+  }
+
+  /**
+   * Gets the advancement node this criterion belongs to.
+   *
+   * @return the advancement node this criterion belongs to
+   */
+  public AdvancementNode getAdvancementNode() {
+    return this.advancementNode;
   }
 
   /**
@@ -40,7 +56,16 @@ public class ReloadedCriterionProgress {
    * @return the advancement this criterion belongs to
    */
   public Advancement getAdvancement() {
-    return this.advancement;
+    return this.advancementNode.holder().value();
+  }
+
+  /**
+   * Gets the resource location of the advancement this criterion belongs to.
+   *
+   * @return the resource location of the advancement this criterion belongs to
+   */
+  public ResourceLocation getResourceLocation() {
+    return this.advancementNode.holder().id();
   }
 
   /**
@@ -59,7 +84,7 @@ public class ReloadedCriterionProgress {
    * @return the title of this criterion progress
    */
   public Component getTitle() {
-    return Component.nullToEmpty(this.criterionName);
+    return Component.nullToEmpty(this.criterion.toString());
   }
 
   /**
@@ -79,5 +104,95 @@ public class ReloadedCriterionProgress {
    */
   public boolean isObtained() {
     return this.obtained;
+  }
+
+  /**
+   * Gets the human-readable name of the criterion.
+   *
+   * @return the human-readable name of the criterion
+   */
+  public Component getHumanCriterionName() {
+    final String translationKey = this.getTranslationKey();
+
+    switch (Configuration.criteriasTranslationMode) {
+      case NONE:
+        // No translation
+        break;
+      case ONLY_COMPATIBLE:
+        // Only translate when compatible with mod
+        return Component.translatableWithFallback(translationKey, this.criterion.getPath());
+      case TRY_TO_TRANSLATE:
+        // Try to translate all the time (try to translate as possible) but
+        // can be a performance hit
+        return Component.translatableWithFallback(translationKey, this.retrieveTranslationOnGame().getString());
+      default:
+        break;
+    }
+
+    return Component.literal(this.criterion.getPath());
+  }
+
+  /**
+   * Gets the translation key for the criterion name. This is used for the
+   * advancement sidebar. The key is formatted as
+   * "advancements.{root-advancement-id}.{advancement-id}.criteria.{criterion-name>}"
+   *
+   * @return the translation key for the criterion name
+   */
+  public String getTranslationKey() {
+    final ResourceLocation advancementId = this.getResourceLocation();
+    final ResourceLocation rootAdvancementId = this.getAdvancementNode().root().holder().id();
+    final String criterionName = this.criterion.getPath();
+
+    // Retrieve the achievement id without path
+    final String[] segments = advancementId.getPath().split("/");
+    final String realAchievementId = segments[segments.length - 1];
+
+    // Retrieve the root achievement id without path
+    final String[] rootSegments = rootAdvancementId.getPath().split("/");
+    final String realRootAchievementId = rootSegments[rootSegments.length - 2];
+
+    final String translationKey = "advancements."
+        + realRootAchievementId
+        + "."
+        + realAchievementId
+        + ".criteria." + criterionName;
+
+    return translationKey;
+  }
+
+  private Component retrieveTranslationOnGame() {
+    final String criterionNamespace = this.criterion.getNamespace();
+    final String criteria = this.criterion.getPath();
+
+    // Try to translate the name by finding the item in the namespace and the
+    // default namespace (if not the same as the namespace).
+    final List<String> namespaces = Lists.newArrayList(criterionNamespace);
+    if (!criterionNamespace.equals("minecraft")) {
+      namespaces.add("minecraft");
+    }
+
+    // CHECKSTYLE:OFF
+    final String[] keyTypes = { "biome", "block", "color", "container", "effect", "enchantment", "entity", "instrument",
+        "item", "jukebox_song", "painting", "stat" };
+    // CHECKSTYLE:ON
+
+    for (final String namespace : namespaces) {
+      for (final String keyType : keyTypes) {
+        // Special case for paintings since they have a different translation key
+        final String translationKey = keyType + "." + namespace + "." + criteria
+            + (keyType == "painting" ? ".title" : "");
+        final Component translation = Component.translatable(translationKey);
+        if (!translation.getString().equals(translationKey)) {
+          translation.getStyle().withItalic(true).applyTo(translation.getStyle());
+          return translation;
+        }
+      }
+    }
+
+    Utils.LOGGER.warn(
+        "Unable to translate {} to a more meaningful name, adding as is, performance may be degraded. You can add your own translation for this criterion by adding the translation key: `{}`.",
+        criteria, this.getTranslationKey());
+    return Component.literal(criteria);
   }
 }

--- a/common/src/main/java/codes/atomys/advr/config/Configuration.java
+++ b/common/src/main/java/codes/atomys/advr/config/Configuration.java
@@ -19,6 +19,7 @@ public final class Configuration {
   public static boolean criteriasAlphabeticOrder = true; // added in v0.3, true by default in v0.5
   public static boolean tabsAlphabeticOrder = true; // added in v0.6
   public static BackgroundStyle backgroundStyle = BackgroundStyle.TRANSPARENT; // added in v0.4
+  public static TranslationMode criteriasTranslationMode = TranslationMode.ONLY_COMPATIBLE; // added in v0.6
 
   // Advanced customization
   public static int headerHeight = 48; // added in v0.2
@@ -29,10 +30,39 @@ public final class Configuration {
 
   /**
    * Enum representing different styles for background configuration.
+   * 
+   * <p>
+   * TRANSPARENT: Background is transparent
+   * </p>
+   * <p>
+   * ACHIEVEMENT: Background is an achievement
+   * </p>
+   * <p>
+   * BLACK: Background is black
+   * </p>
    */
   public enum BackgroundStyle {
     TRANSPARENT,
     ACHIEVEMENT,
     BLACK,
+  }
+
+  /**
+   * Enum representing different translation modes.
+   *
+   * <p>
+   * NONE: No translation
+   * </p>
+   * <p>
+   * ONLY_COMPATIBLE: Only translate advancements that are compatible
+   * </p>
+   * <p>
+   * ALL: Translate all advancements
+   * </p>
+   */
+  public enum TranslationMode {
+    NONE,
+    ONLY_COMPATIBLE,
+    TRY_TO_TRANSLATE,
   }
 }

--- a/common/src/main/java/codes/atomys/advr/config/ModConfigurationFile.java
+++ b/common/src/main/java/codes/atomys/advr/config/ModConfigurationFile.java
@@ -48,6 +48,7 @@ public final class ModConfigurationFile {
     appearance.set("criterias_alphabetic_order", Configuration.criteriasAlphabeticOrder);
     appearance.set("tabs_alphabetic_order", Configuration.tabsAlphabeticOrder);
     appearance.set("background_style", Configuration.backgroundStyle.name());
+    appearance.set("criterias_translation_mode", Configuration.criteriasTranslationMode.name());
 
     final Config advancedCustomization = Config.inMemory();
     advancedCustomization.set("header_height", Configuration.headerHeight);
@@ -95,6 +96,8 @@ public final class ModConfigurationFile {
     Configuration.tabsAlphabeticOrder = appearance.getOrElse("tabs_alphabetic_order", true);
     Configuration.backgroundStyle = Configuration.BackgroundStyle
         .valueOf(appearance.getOrElse("background_style", "TRANSPARENT").toUpperCase());
+    Configuration.criteriasTranslationMode = Configuration.TranslationMode
+        .valueOf(appearance.getOrElse("criterias_translation_mode", "ONLY_COMPATIBLE").toUpperCase());
 
     Configuration.headerHeight = advancedCustomization.getOrElse("header_height", 48);
     Configuration.footerHeight = advancedCustomization.getOrElse("footer_height", 32);

--- a/common/src/main/java/codes/atomys/advr/config/gui/ConfigurationScreen.java
+++ b/common/src/main/java/codes/atomys/advr/config/gui/ConfigurationScreen.java
@@ -166,6 +166,17 @@ public final class ConfigurationScreen {
                 Component.translatable("text.config.advancements_reloaded.option.background_style.tooltip"))
             .setSaveConsumer(newValue -> Configuration.backgroundStyle = newValue)
             .build());
+
+    appearance.addEntry(
+        entryBuilder
+            .startEnumSelector(
+                Component.translatable("text.config.advancements_reloaded.option.criterias_translation_mode"),
+                Configuration.TranslationMode.class, Configuration.criteriasTranslationMode)
+            .setDefaultValue(Configuration.TranslationMode.ONLY_COMPATIBLE)
+            .setTooltip(
+                Component.translatable("text.config.advancements_reloaded.option.criterias_translation_mode.tooltip"))
+            .setSaveConsumer(newValue -> Configuration.criteriasTranslationMode = newValue)
+            .build());
   }
 
   private static void createAdvancedCustomizationEntries(final ConfigBuilder builder) {

--- a/common/src/main/java/codes/atomys/advr/screens/AdvancementReloadedScreen.java
+++ b/common/src/main/java/codes/atomys/advr/screens/AdvancementReloadedScreen.java
@@ -549,13 +549,14 @@ public class AdvancementReloadedScreen extends Screen implements ClientAdvanceme
       return;
 
     int paddingTop = Configuration.headerHeight + 6;
-    final int textWidth = Configuration.criteriasWidth - 12 - 6;
+    final int sidebarXOffset = width - Configuration.criteriasWidth + 8;
+    // 6 are the scrollbar width and 12 (6[left]-6[right]) are the right margin
+    final int maxTextWidth = Configuration.criteriasWidth - (this.needScrollbarOnCriterias() ? 6 : 0) - 12;
 
     final Component title = this.getSelectedWidget().getAdvancement().name().get();
     final Component description = this.getSelectedWidget().getAdvancement().display().get().getDescription();
 
-    context.fill(width - Configuration.criteriasWidth,
-        Configuration.headerHeight, width,
+    context.fill(width - Configuration.criteriasWidth, Configuration.headerHeight, width,
         height - Configuration.footerHeight, Mth.floor(0.5F * 255.0F) << 24);
 
     context.blit(criteriasSeparator, width - Configuration.criteriasWidth,
@@ -571,37 +572,32 @@ public class AdvancementReloadedScreen extends Screen implements ClientAdvanceme
     this.contentHeight = 6; // 6 are the bottom margin
 
     // Drawing title
-    context.drawWordWrap(this.font, title, width - Configuration.criteriasWidth + 8,
-        paddingTop,
-        textWidth, CommonColors.WHITE);
-    paddingTop += (this.font.lineHeight) * this.font.split(title, textWidth).size() + 4;
-    this.contentHeight += (this.font.lineHeight) * this.font.split(title, textWidth).size() + 4;
+    context.drawWordWrap(this.font, title, sidebarXOffset, paddingTop, maxTextWidth, CommonColors.WHITE);
+    // 4 are the padding bottom added
+    paddingTop += (this.font.lineHeight) * this.font.split(title, maxTextWidth).size() + 4;
+    this.contentHeight += (this.font.lineHeight) * this.font.split(title, maxTextWidth).size() + 4;
 
     // Drawing description
     if (Configuration.displayDescription && description != null) {
-      context.drawWordWrap(this.font, description,
-          width - Configuration.criteriasWidth + 8,
-          paddingTop,
-          textWidth,
+      context.drawWordWrap(this.font, description, sidebarXOffset, paddingTop, maxTextWidth,
           this.getSelectedWidget().getAdvancement().display().get().getType().getChatColor().getColor());
-      paddingTop += (this.font.lineHeight) * this.font.split(description, textWidth).size() + 4;
-      this.contentHeight += (this.font.lineHeight) * this.font.split(description, textWidth).size() + 4;
+      // 4 are the padding bottom added
+      paddingTop += (this.font.lineHeight) * this.font.split(description, maxTextWidth).size() + 4;
+      this.contentHeight += (this.font.lineHeight) * this.font.split(description, maxTextWidth).size() + 4;
     }
 
-    context.hLine(width - Configuration.criteriasWidth + 8, width - 12, paddingTop,
-        CommonColors.LIGHT_GRAY);
+    context.hLine(sidebarXOffset, width - 12, paddingTop, CommonColors.LIGHT_GRAY);
     paddingTop += 5;
     this.contentHeight += 5;
 
     // Drawing criterias
     for (final ReloadedCriterionProgress step : this.getSelectedWidget().getSteps()) {
-      context.drawWordWrap(this.font, step.getTitle(),
-          width - Configuration.criteriasWidth + 8,
-          paddingTop, textWidth, step.getColor());
-      paddingTop += (this.font.lineHeight) * this.font.split(step.getTitle(), textWidth).size()
-          + 4;
-      this.contentHeight += (this.font.lineHeight) * this.font.split(step.getTitle(), textWidth).size()
-          + 4;
+      final Component stepTitle = step.getHumanCriterionName();
+      final int lineNeeded = this.font.split(stepTitle, maxTextWidth).size();
+      context.drawWordWrap(this.font, stepTitle, sidebarXOffset, paddingTop, maxTextWidth, step.getColor());
+      // 4 are the padding bottom added
+      paddingTop += (this.font.lineHeight) * lineNeeded + 4;
+      this.contentHeight += (this.font.lineHeight) * lineNeeded + 4;
     }
 
     postStack.popPose();

--- a/common/src/main/java/codes/atomys/advr/screens/AdvancementReloadedWidget.java
+++ b/common/src/main/java/codes/atomys/advr/screens/AdvancementReloadedWidget.java
@@ -365,10 +365,10 @@ public class AdvancementReloadedWidget {
     }
 
     remainingCriteriaIterable.forEach((criterion) -> {
-      steps.add(new ReloadedCriterionProgress(this.advancement.advancement(), progress, criterion));
+      steps.add(new ReloadedCriterionProgress(this.advancement, progress, criterion));
     });
     completedCriteriaIterable.forEach((criterion) -> {
-      steps.add(new ReloadedCriterionProgress(this.advancement.advancement(), progress, criterion));
+      steps.add(new ReloadedCriterionProgress(this.advancement, progress, criterion));
     });
 
     this.steps = steps;

--- a/common/src/main/resources/assets/advancements_reloaded/lang/en_us.json
+++ b/common/src/main/resources/assets/advancements_reloaded/lang/en_us.json
@@ -12,6 +12,8 @@
   "text.config.advancements_reloaded.option.tabs_alphabetic_order.tooltip": "[true] Display the tabs in alphabetical order\n[false] Display the tabs in vanilla like (random).",
   "text.config.advancements_reloaded.option.background_style": "Background Style in Advancement Screen",
   "text.config.advancements_reloaded.option.background_style.tooltip": "Choose the style of the background in the advancement screen.",
+  "text.config.advancements_reloaded.option.criterias_translation_mode": "Criterias Translation Mode",
+  "text.config.advancements_reloaded.option.criterias_translation_mode.tooltip": "Choose the translation mode of the criteria text in the advancement screen.",
   "text.config.advancements_reloaded.option.header_height": "Header Height",
   "text.config.advancements_reloaded.option.header_height.tooltip": "The height of the header area, measured in pixels.\nAdjust this value to increase or decrease the vertical space for the header.",
   "text.config.advancements_reloaded.option.footer_height": "Footer Height",
@@ -24,5 +26,8 @@
   "text.config.advancements_reloaded.option.below_widget_limit.tooltip": "The maximum number of widgets that can be displayed in the footer area.\nThis sets the upper limit for how many interactive elements can be shown in the footer.\n\nWarning: Be careful because too many widgets can cause some to be hidden off-screen.",
   "text.config.advancements_reloaded.enum.background_style.transparent": "Transparent Blur",
   "text.config.advancements_reloaded.enum.background_style.black": "Full Black",
-  "text.config.advancements_reloaded.enum.background_style.achievement": "Achievement Display"
+  "text.config.advancements_reloaded.enum.background_style.achievement": "Achievement Display",
+  "text.config.advancements_reloaded.enum.criterias_translation_mode.none": "Display As Is",
+  "text.config.advancements_reloaded.enum.criterias_translation_mode.only_compatible": "Only Compatible With Mod",
+  "text.config.advancements_reloaded.enum.criterias_translation_mode.try_to_translate": "Try To Translate As Possible"
 }

--- a/docs/changelogs/0.6.0.md
+++ b/docs/changelogs/0.6.0.md
@@ -3,4 +3,5 @@
 
 ### 🚀 Features
 
-- **New Tab Ordering**: Tabs can now be ordered alphabetically (by translated name) or in the default order (vanilla order)
+- **New Tab Ordering**: Tabs can now be ordered alphabetically (by translated name) or in the default order (vanilla order) [PR #24](https://github.com/42atomys/mc-advancements-reloaded/pull/24)
+- **Criterias Translation**: Criterias can now be translated officially by the community (see [wiki page](https://github.com/42atomys/mc-advancements-reloaded/wiki/Translation) [PR #25](https://github.com/42atomys/mc-advancements-reloaded/pull/25)


### PR DESCRIPTION
This pull request introduces a new feature that allows for the translation of criteria within the advancement screen. 

Users can now select a translation mode, which includes options for no translation, only translating compatible advancements, or attempting to translate all advancements. 

Additionally, the tab ordering has been enhanced to support alphabetical sorting based on translated names. 

This update aims to improve user experience by providing more flexibility in how criteria are displayed.