### PR TITLE
fix: crash when no criterias

### DIFF
--- a/common/src/main/java/codes/atomys/advr/screens/AdvancementReloadedWidget.java
+++ b/common/src/main/java/codes/atomys/advr/screens/AdvancementReloadedWidget.java
@@ -249,6 +249,10 @@ public class AdvancementReloadedWidget {
    *         criteria
    */
   public List<ReloadedCriterionProgress> getSteps() {
+    if (this.steps == null) {
+      return new ArrayList<>();
+    }
+
     return this.steps;
   }
 

--- a/common/src/main/java/codes/atomys/advr/screens/AdvancementReloadedWidget.java
+++ b/common/src/main/java/codes/atomys/advr/screens/AdvancementReloadedWidget.java
@@ -5,6 +5,7 @@ import codes.atomys.advr.config.Configuration;
 import codes.atomys.advr.utils.Utils;
 import com.google.common.collect.Lists;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Function;
@@ -250,7 +251,7 @@ public class AdvancementReloadedWidget {
    */
   public List<ReloadedCriterionProgress> getSteps() {
     if (this.steps == null) {
-      return new ArrayList<>();
+      return Collections.emptyList();
     }
 
     return this.steps;

--- a/docs/changelogs/0.8.1.md
+++ b/docs/changelogs/0.8.1.md
@@ -4,4 +4,4 @@
 ### 🐛 Fixes
 
 - **Missing texture**: Due to binding changes, a missing texture is displayed [PR #58](https://github.com/42atomys/mc-advancements-reloaded/pull/58)
-- **Where are my criterias**: Game crash when no criterias are attached to the achievement [PR #59](https://github.com/42atomys/mc-advancements-reloaded/pull/59)
+- **Where are my criteria**: Game crash when no criteria are attached to the achievement [PR #59](https://github.com/42atomys/mc-advancements-reloaded/pull/59)

--- a/docs/changelogs/0.8.1.md
+++ b/docs/changelogs/0.8.1.md
@@ -4,3 +4,4 @@
 ### 🐛 Fixes
 
 - **Missing texture**: Due to binding changes, a missing texture is displayed [PR #58](https://github.com/42atomys/mc-advancements-reloaded/pull/58)
+- **Where are my criterias**: Game crash when no criterias are attached to the achievement [PR #59](https://github.com/42atomys/mc-advancements-reloaded/pull/59)


### PR DESCRIPTION
This pull request includes a fix to prevent a game crash when no criteria are attached to an achievement and an update to the changelog to reflect this fix.