### PR TITLE
fix(search): internal naming are used on search result

### DIFF
--- a/common/src/main/java/codes/atomys/advr/screens/AdvancementReloadedWidget.java
+++ b/common/src/main/java/codes/atomys/advr/screens/AdvancementReloadedWidget.java
@@ -3,6 +3,7 @@ package codes.atomys.advr.screens;
 import codes.atomys.advr.ReloadedCriterionProgress;
 import codes.atomys.advr.ReloadedWidgetType;
 import codes.atomys.advr.config.Configuration;
+import codes.atomys.advr.utils.TextUtils;
 import codes.atomys.advr.utils.Utils;
 import com.google.common.collect.Lists;
 import com.mojang.blaze3d.pipeline.RenderPipeline;
@@ -273,19 +274,20 @@ public class AdvancementReloadedWidget {
 
     final String searchLower = search.toLowerCase();
     // Pass by display getTitle getString to have the translated string
-    if (this.display.getTitle().getString().toLowerCase().contains(searchLower) ||
-        this.title.toString().toLowerCase().contains(searchLower)) {
+    if (TextUtils.toString(this.display.getTitle()).toLowerCase()
+        .contains(searchLower)) {
       return true;
     }
 
     for (final FormattedCharSequence line : this.description) {
-      if (line.toString().toLowerCase().contains(searchLower)) {
+      if (TextUtils.toString(line).toLowerCase().contains(searchLower)) {
         return true;
       }
     }
 
     for (final ReloadedCriterionProgress step : this.steps) {
-      if (step.getHumanCriterionName().toString().toLowerCase().contains(searchLower)) {
+      if (TextUtils.toString(step.getHumanCriterionName()).toLowerCase()
+          .contains(searchLower)) {
         return true;
       }
     }

--- a/common/src/main/java/codes/atomys/advr/utils/TextUtils.java
+++ b/common/src/main/java/codes/atomys/advr/utils/TextUtils.java
@@ -1,0 +1,49 @@
+package codes.atomys.advr.utils;
+
+import net.minecraft.network.chat.Component;
+import net.minecraft.util.FormattedCharSequence;
+
+/**
+ * Utility class for text-related operations, particularly for converting
+ * formatted character sequences and components to plain strings.
+ */
+public final class TextUtils {
+  private TextUtils() {
+    throw new UnsupportedOperationException("Utility class");
+  }
+
+  /**
+   * Converts a {@link FormattedCharSequence} to a plain {@link String}.
+   *
+   * @param charSequence the formatted character sequence to convert
+   * @return the plain string representation of the character sequence
+   */
+  public static String toString(final FormattedCharSequence charSequence) {
+    if (charSequence == null) {
+      return "";
+    }
+
+    // You'd need to extract the text content by iterating through the sequence
+    final StringBuilder builder = new StringBuilder();
+    charSequence.accept((index, style, codepoint) -> {
+      builder.appendCodePoint(codepoint);
+      return true;
+    });
+
+    return builder.toString();
+  }
+
+  /**
+   * Converts a {@link Component} to a plain {@link String}.
+   *
+   * @param component the component to convert
+   * @return the plain string representation of the component
+   */
+  public static String toString(final Component component) {
+    if (component == null) {
+      return "";
+    }
+    return toString(component.getVisualOrderText());
+  }
+
+}


### PR DESCRIPTION
This pull request introduces a new utility class, `TextUtils`, to streamline text conversion operations and refactors existing code to use this utility. The changes improve readability, maintainability, and consistency in handling text-related operations.

### Refactoring for text conversion:

* **Added `TextUtils` utility class**: Created a new utility class in `common/src/main/java/codes/atomys/advr/utils/TextUtils.java` to handle conversions of `FormattedCharSequence` and `Component` objects to plain strings. This reduces redundancy and centralizes text-related logic.

* **Refactored `isSearchQueryMatched` method**: Updated the `isSearchQueryMatched` method in `common/src/main/java/codes/atomys/advr/screens/AdvancementReloadedWidget.java` to use the new `TextUtils.toString` method for converting various objects to plain strings. This simplifies the logic and ensures consistent text processing.