### PR TITLE
fix(render): horrible performance when searching (#95)

### DIFF
--- a/common/src/main/java/codes/atomys/advr/screens/AdvancementReloadedScreen.java
+++ b/common/src/main/java/codes/atomys/advr/screens/AdvancementReloadedScreen.java
@@ -1231,13 +1231,18 @@ public class AdvancementReloadedScreen extends Screen implements ClientAdvanceme
 
   /**
    * Called when the search text changes.
-   * Updates the search text field and triggers a search across all advancements.
+   * Updates the search text field and triggers a search across all advancements,
+   * as well as updating each tab, on if it contains a widget match.
    *
    * @param text the new search text
    */
   private void onSearchTextChanged(final String text) {
     this.searchText = text;
     this.isSearching = !text.isEmpty();
+    // Update which tabs have a widget match
+    for (final AdvancementReloadedTab tab : this.tabs.values()) {
+      tab.updateDoesWidgetMatchSearch();
+    }
     // Refresh the screen to show search results
     this.initClickableRegions();
   }

--- a/common/src/main/java/codes/atomys/advr/screens/AdvancementReloadedTab.java
+++ b/common/src/main/java/codes/atomys/advr/screens/AdvancementReloadedTab.java
@@ -65,6 +65,7 @@ public class AdvancementReloadedTab {
   private final Component title;
   private final AdvancementReloadedWidget rootWidget;
   private final Map<AdvancementHolder, AdvancementReloadedWidget> widgets = Maps.newLinkedHashMap();
+  private boolean doesAnyWidgetMatchSearch = true;
   private TabPlacement tabPlacement;
   private int index;
   private double originX;
@@ -319,17 +320,27 @@ public class AdvancementReloadedTab {
 
   /**
    * Checks if any widget in the collection matches the given search query.
+   * This value is cached for performance reasons and should only be
+   * updated when the search query changes.
    *
    * @return {@code true} if at least one widget matches the search query,
    *         {@code false} otherwise.
    */
   public boolean isAnyWidgetMatchSearch() {
+    return this.doesAnyWidgetMatchSearch;
+  }
+
+  /**
+   * Updates if any widget in the collection matches the given search query.
+   */
+  public void updateDoesWidgetMatchSearch() {
     for (final AdvancementReloadedWidget widget : this.widgets.values()) {
       if (widget.isSearchQueryMatched()) {
-        return true;
+        this.doesAnyWidgetMatchSearch = true;
+        return;
       }
     }
-    return false;
+    this.doesAnyWidgetMatchSearch = false;
   }
 
   /**


### PR DESCRIPTION
Only recompute AdvancementReloadedTab#isAnyWidgetMatchSearch when value of search text changes. This massively improves performance, when a lot of tabs are present and searching for something.

performance after the patch: 
<img width="1004" height="993" alt="image" src="https://github.com/user-attachments/assets/2c462774-313c-431a-bc97-9b87a74aecdc" />

now there is no performance loss when searching

fixes #95 