### PR TITLE
fix: ordering on server and when configuration changes

### DIFF
--- a/common/src/main/java/codes/atomys/advr/AdvancementTreeRecalculator.java
+++ b/common/src/main/java/codes/atomys/advr/AdvancementTreeRecalculator.java
@@ -1,0 +1,51 @@
+package codes.atomys.advr;
+
+import codes.atomys.advr.utils.Utils;
+import net.minecraft.advancements.AdvancementNode;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.multiplayer.ClientAdvancements;
+
+/**
+ * Utility class for recalculating advancement tree positions.
+ * <p>
+ * This is useful when configuration changes (e.g., advancement order mode)
+ * and all trees need to be repositioned without reloading advancements.
+ * </p>
+ */
+public final class AdvancementTreeRecalculator {
+
+  /**
+   * Private constructor to prevent instantiation of the utility class.
+   * Throws {@link UnsupportedOperationException} if called.
+   */
+  private AdvancementTreeRecalculator() {
+    throw new UnsupportedOperationException("Utility class");
+  }
+
+  /**
+   * Recalculates all advancement tree positions using the current configuration.
+   * This should be called when advancement ordering settings change.
+   */
+  public static void recalculateAll() {
+    final Minecraft minecraft = Minecraft.getInstance();
+    if (minecraft.player == null || minecraft.player.connection == null) {
+      return;
+    }
+
+    final ClientAdvancements advancements = minecraft.player.connection.getAdvancements();
+    if (advancements == null) {
+      return;
+    }
+
+    Utils.LOGGER.info("Recalculating all advancement tree positions due to configuration change");
+
+    // Recalculate position for each root advancement
+    for (final AdvancementNode root : advancements.getTree().roots()) {
+      if (root.advancement().display().isPresent()) {
+        AdvancementTreePositioning.run(root);
+      }
+    }
+
+    Utils.LOGGER.info("Advancement tree positions recalculated");
+  }
+}

--- a/common/src/main/java/codes/atomys/advr/config/gui/ConfigurationScreen.java
+++ b/common/src/main/java/codes/atomys/advr/config/gui/ConfigurationScreen.java
@@ -1,5 +1,6 @@
 package codes.atomys.advr.config.gui;
 
+import codes.atomys.advr.AdvancementTreeRecalculator;
 import codes.atomys.advr.config.Configuration;
 import codes.atomys.advr.config.ModConfigurationFile;
 import me.shedaniel.clothconfig2.api.ConfigBuilder;
@@ -99,12 +100,27 @@ public final class ConfigurationScreen {
    * @return a ConfigBuilder with various configuration settings.
    */
   public static ConfigBuilder configBuilder(final Screen parent) {
+    // Store the original ordering settings to detect changes
+    final Configuration.AdvancementOrder originalAdvancementsOrder = Configuration.advancementsOrder;
+    final java.util.List<String> originalCustomAdvancementsOrder =
+        new java.util.ArrayList<>(Configuration.customAdvancementsOrder);
 
     final ConfigBuilder builder = ConfigBuilder.create()
         .setParentScreen(parent)
         .setTransparentBackground(true)
         .setTitle(Component.translatable("text.config.advancements_reloaded.title"))
-        .setSavingRunnable(ModConfigurationFile.saveRunnable);
+        .setSavingRunnable(() -> {
+          // Save configuration to file
+          ModConfigurationFile.saveRunnable.run();
+
+          // Recalculate tree positions if advancement ordering changed
+          final boolean orderModeChanged = originalAdvancementsOrder != Configuration.advancementsOrder;
+          final boolean customOrderChanged = !originalCustomAdvancementsOrder.equals(Configuration.customAdvancementsOrder);
+
+          if (orderModeChanged || (customOrderChanged && Configuration.advancementsOrder == Configuration.AdvancementOrder.CONFIGURED_ORDER)) {
+            AdvancementTreeRecalculator.recalculateAll();
+          }
+        });
 
     createApparanceEntries(builder);
     createAdvancedCustomizationEntries(builder);

--- a/common/src/main/java/codes/atomys/advr/mixin/AdvancementTreeMixin.java
+++ b/common/src/main/java/codes/atomys/advr/mixin/AdvancementTreeMixin.java
@@ -1,0 +1,57 @@
+package codes.atomys.advr.mixin;
+
+import codes.atomys.advr.AdvancementTreePositioning;
+import java.util.Set;
+import net.minecraft.advancements.AdvancementNode;
+import net.minecraft.advancements.AdvancementTree;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+/**
+ * Mixin to recalculate advancement tree positions when advancements are
+ * received
+ * from the server in multiplayer.
+ * <p>
+ * In multiplayer, the server calculates positions using vanilla
+ * TreeNodePosition
+ * and sends pre-calculated positions to clients. This mixin intercepts when
+ * a root advancement is added on the client and forces a recalculation using
+ * our custom ordering algorithm.
+ * </p>
+ */
+@Mixin(AdvancementTree.class)
+public class AdvancementTreeMixin {
+
+  @Shadow
+  @Final
+  private Set<AdvancementNode> roots;
+
+  /**
+   * Recalculates tree positions after a root advancement is inserted.
+   * This ensures custom ordering is applied even in multiplayer where
+   * positions are received from the server.
+   *
+   * @param advancement the advancement holder that was inserted
+   * @param cir         the callback info returnable
+   */
+  @Inject(method = "tryInsert", at = @At("RETURN"))
+  private void recalculateTreePositions(
+      final net.minecraft.advancements.AdvancementHolder advancement,
+      final CallbackInfoReturnable<Boolean> cir) {
+    // Only recalculate if insertion was successful and it's a root advancement
+    if (cir.getReturnValue() && advancement.value().parent().isEmpty()) {
+      // Find the newly added root node
+      for (final AdvancementNode root : this.roots) {
+        if (root.holder().equals(advancement) && root.advancement().display().isPresent()) {
+          // Force recalculation of tree positions using our custom algorithm
+          AdvancementTreePositioning.run(root);
+          break;
+        }
+      }
+    }
+  }
+}

--- a/common/src/main/resources/advancements_reloaded.mixins.json
+++ b/common/src/main/resources/advancements_reloaded.mixins.json
@@ -4,6 +4,7 @@
   "compatibilityLevel": "JAVA_17",
   "minVersion": "0.8",
   "client": [
+    "AdvancementTreeMixin",
     "MinecraftClientMixin",
     "PauseScreenMixin",
     "TreeNodePositionMixin"


### PR DESCRIPTION
This pull request introduces a mechanism to ensure advancement tree positions are recalculated whenever the advancement ordering configuration changes, both in singleplayer and multiplayer contexts. The changes include a new utility class for recalculating tree positions, updates to the configuration screen to trigger recalculation on relevant config changes, and a mixin to handle recalculation when advancements are received from the server.

### Advancement tree recalculation utilities

* Added a new utility class `AdvancementTreeRecalculator` to centralize and simplify the process of recalculating all advancement tree positions when configuration changes occur.